### PR TITLE
Add proxmox cidata support

### DIFF
--- a/functional-tests/CloudbaseInit.Tests.ps1
+++ b/functional-tests/CloudbaseInit.Tests.ps1
@@ -350,6 +350,10 @@ function prepare.nocloud {
     popd
 }
 
+function prepare.proxmox {
+    & prepare.nocloud
+}
+
 function prepare.vmwareguest {
     pushd "$here/../$($env:CLOUD)"
         $openVpnTapAdapterMacAddress = Prepare-OpenVPNTapAdapter

--- a/proxmox/cloudbase-init-metadata/META_DATA
+++ b/proxmox/cloudbase-init-metadata/META_DATA
@@ -1,0 +1,1 @@
+instance-id: b5d7ad9def3de8f296d996d61614a9358b26f380

--- a/proxmox/cloudbase-init-metadata/USER_DATA
+++ b/proxmox/cloudbase-init-metadata/USER_DATA
@@ -1,0 +1,11 @@
+#cloud-config
+hostname: avladu-test-proxmox
+manage_etc_hosts: true
+fqdn: avladu-test-proxmox.maas.local
+user: Admin2
+password: Passw0rd12354!!
+chpasswd:
+  expire: False
+users:
+  - default
+package_upgrade: true

--- a/proxmox/cloudbase-init.conf
+++ b/proxmox/cloudbase-init.conf
@@ -1,0 +1,358 @@
+[DEFAULT]
+
+debug = true
+logfile = 
+#
+# From cloudbaseinit.conf
+#
+
+# Allows OS reboots requested by plugins (boolean value)
+allow_reboot = false
+
+# In case of execution as a service, specifies if the service must be gracefully
+# stopped before exiting (boolean value)
+stop_service_on_exit = false
+
+# Check if there is a newer version of cloudbase-init available.  If this option
+# is activated, a log message  will be  emitted if there is a newer version
+# available. (boolean value)
+#check_latest_version = false
+
+# Max. number of attempts for fetching metadata in case of transient errors
+# (integer value)
+#retry_count = 5
+
+# Interval between attempts in case of transient errors, expressed in seconds
+# (floating point value)
+#retry_count_interval = 4
+
+# Path to "mtools" program suite, used for interacting with VFAT filesystems
+# (string value)
+mtools_path = none
+
+# Path to "bsdtar", used to extract ISO ConfigDrive files (string value)
+#bsdtar_path = bsdtar.exe
+
+# Truncates the hostname to 15 characters for Netbios compatibility (boolean
+# value)
+#netbios_host_name_compatibility = true
+
+# Serial port logging settings. Format: "port,baudrate,parity,bytesize", e.g.:
+# "COM1,115200,N,8". Set to None (default) to disable. (string value)
+#logging_serial_port_settings = <None>
+
+# Activates Windows automatically (boolean value)
+#activate_windows = false
+
+# Sets the KMS product key for this operating system (boolean value)
+#set_kms_product_key = false
+
+# Sets the AVMA product key for this operating system (boolean value)
+#set_avma_product_key = false
+
+# The KMS host address in form <host>[:<port>], e.g: "kmshost:1688" (string
+# value)
+#kms_host = <None>
+
+# Logs the operating system licensing information (boolean value)
+#log_licensing_info = true
+
+# Enables basic authentication for the WinRM HTTPS listener (boolean value)
+#winrm_enable_basic_auth = true
+
+# Configures the WinRM HTTP listener (boolean value)
+#winrm_configure_http_listener = false
+
+# Configures the WinRM HTTPS listener (boolean value)
+#winrm_configure_https_listener = true
+
+# List of volumes that need to be extended if contiguous space is available on
+# the disk. By default all the available volumes can be extended. Volumes must
+# be specified using a comma separated list of volume indexes, e.g.: "1,2" (list
+# value)
+#volumes_to_extend = <None>
+
+# If not None, the SAN policy is set to the given value (string value)
+# Possible values:
+# OnlineAll - <No description provided>
+# OfflineAll - <No description provided>
+# OfflineShared - <No description provided>
+san_policy = OnlineAll
+
+# Path location containing scripts to be executed when the plugin runs (string
+# value)
+#local_scripts_path = <None>
+
+# Configures the network interfaces MTU based on the values provided via DHCP
+# (boolean value)
+#mtu_use_dhcp_config = true
+
+# User to be added to the system or updated if already existing (string value)
+#username = Admin
+
+# List of local groups to which the user specified in "username" will be added
+# (list value)
+#groups = Administrators
+
+# Renames the builtin admin user instead of creating a new user (boolean value)
+#rename_admin_user = false
+
+# The directory where the Heat configuration files must be saved (string value)
+#heat_config_dir = C:\cfn
+
+# Enables the NTP client service (boolean value)
+#ntp_enable_service = true
+
+# Configures NTP client time synchronization using the NTP servers provided via
+# DHCP (boolean value)
+#ntp_use_dhcp_config = false
+
+# Sets the real time clock to use universal time (True) or local time (False)
+# (boolean value)
+#real_time_clock_utc = false
+
+# Set the password provided in the configuration. If False or no password is
+# provided, a random one will be set (boolean value)
+#inject_user_password = true
+
+# Control the behaviour of what happens at next logon. If this option is set to
+# `always`, then the user will be forced to change the password at next logon.
+# If it is set to `clear_text_injected_only`, then the user will have to change
+# the password only if the password is a clear text password, coming from the
+# metadata. The last option is `no`, when the user is never forced to change the
+# password. (string value)
+# Possible values:
+# clear_text_injected_only - <No description provided>
+# no - <No description provided>
+# always - <No description provided>
+#first_logon_behaviour = clear_text_injected_only
+
+# List of enabled metadata service classes, to be tested for availability in the
+# provided order. The first available service will be used to retrieve metadata
+# (list value)
+metadata_services = cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService
+
+#,cloudbaseinit.metadata.services.ec2service.EC2Service,cloudbaseinit.metadata.services.maasservice.MaaSHttpService,cloudbaseinit.metadata.services.cloudstack.CloudStack,cloudbaseinit.metadata.services.opennebulaservice.OpenNebulaService
+
+# List of enabled plugin classes, to be executed in the provided order (list
+# value)
+plugins = cloudbaseinit.plugins.common.mtu.MTUPlugin,cloudbaseinit.plugins.windows.ntpclient.NTPClientPlugin,cloudbaseinit.plugins.windows.sanpolicy.SANPolicyPlugin,cloudbaseinit.plugins.windows.displayidletimeout.DisplayIdleTimeoutConfigPlugin,cloudbaseinit.plugins.windows.bootconfig.BootStatusPolicyPlugin,cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin,cloudbaseinit.plugins.windows.createuser.CreateUserPlugin,cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin,cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin,cloudbaseinit.plugins.common.userdata.UserDataPlugin,cloudbaseinit.plugins.common.setuserpassword.SetUserPasswordPlugin,cloudbaseinit.plugins.windows.winrmlistener.ConfigWinRMListenerPlugin,cloudbaseinit.plugins.windows.winrmcertificateauth.ConfigWinRMCertificateAuthPlugin,cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin,cloudbaseinit.plugins.common.trim.TrimConfigPlugin,cloudbaseinit.plugins.common.networkconfig.NetworkConfigPlugin
+
+# List of enabled userdata content plugins (list value)
+#user_data_plugins = cloudbaseinit.plugins.common.userdataplugins.parthandler.PartHandlerPlugin,cloudbaseinit.plugins.common.userdataplugins.cloudconfig.CloudConfigPlugin,cloudbaseinit.plugins.common.userdataplugins.cloudboothook.CloudBootHookPlugin,cloudbaseinit.plugins.common.userdataplugins.shellscript.ShellScriptPlugin,cloudbaseinit.plugins.common.userdataplugins.multipartmixed.MultipartMixedPlugin,cloudbaseinit.plugins.common.userdataplugins.heat.HeatPlugin
+
+# List which contains the name of the cloud config plugins ordered by priority.
+# (list value)
+#cloud_config_plugins =
+
+# Sets the RDP KeepAlive policy (boolean value)
+rdp_set_keepalive = true
+
+# Sets the Windows BCD boot status policy (string value)
+# Possible values:
+# ignoreallfailures - <No description provided>
+bcd_boot_status_policy = ignoreallfailures
+
+# Enables or disables the BCD auto recovery (boolean value)
+#bcd_enable_auto_recovery = false
+
+# Sets a new random unique id on the boot disk to avoid collisions (boolean
+# value)
+#set_unique_boot_disk_id = true
+
+# The idle timeout, in seconds, before powering off the display. Set 0 to leave
+# the display always on (integer value)
+display_idle_timeout = 0
+
+# Labels of volumes on which a Windows page file needs to be created. E.g.:
+# "Temporary Storage" (list value)
+#page_file_volume_labels =
+
+# Volume mount points on which a Windows page file needs to be created. E.g.:
+# "\\?\GLOBALROOT\device\Harddisk1\Partition1\" (list value)
+#page_file_volume_mount_points =
+
+# Enables or disables TRIM delete notifications for the underlying storage
+# device. (boolean value)
+trim_enabled = true
+
+# Processes the userdata content based on the type, e.g. executing a PowerShell
+# script (boolean value)
+#process_userdata = true
+
+# Copies the userdata to the given file path. The path can include environment
+# variables that will be expanded, e.g.
+# "%%SYSTEMDRIVE%%\CloudbaseInit\UserData.bin" (string value)
+#userdata_save_path = <None>
+
+# If set, enables or disables automatic operating system updates. (boolean
+# value)
+enable_automatic_updates = true
+
+# Reports to the metadata service that provisioning has started (boolean value)
+#metadata_report_provisioning_started = false
+
+# Reports to the metadata service that provisioning completed successfully or
+# failed (boolean value)
+#metadata_report_provisioning_completed = false
+
+# Ephemeral disk volume label, e.g.: "Temporary Storage" (string value)
+#ephemeral_disk_volume_label = <None>
+
+# Ephemeral disk volume mount point,
+# e.g.:"\\?\GLOBALROOT\device\Harddisk1\Partition1\" (string value)
+#ephemeral_disk_volume_mount_point = <None>
+
+# Ephemeral disk data loss warning path, relative to the ephemeral disk volume
+# path. E.g.: DATALOSS_WARNING_README.txt (string value)
+#ephemeral_disk_data_loss_warning_path = <None>
+
+# The length of the generated password for the user defined by the `username`
+# config option. (integer value)
+#user_password_length = 20
+
+
+[azure]
+
+#
+# From cloudbaseinit.conf
+#
+
+# Certificate store name for metadata certificates (string value)
+#transport_cert_store_name = Windows Azure Environment
+
+
+[cloudstack]
+
+#
+# From cloudbaseinit.conf
+#
+
+# The base URL where the service looks for metadata (string value)
+# Deprecated group/name - [DEFAULT]/cloudstack_metadata_ip
+#metadata_base_url = http://10.1.1.1/
+
+# The port number used by the Password Server. (integer value)
+#password_server_port = 8080
+
+# Whether to disable the validation of HTTPS certificates. (boolean value)
+#https_allow_insecure = false
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CAs.
+# (string value)
+#https_ca_bundle = <None>
+
+
+[config_drive]
+
+#
+# From cloudbaseinit.conf
+#
+
+# DEPRECATED: Look for an ISO config drive in raw HDDs (boolean value)
+# Deprecated group/name - [DEFAULT]/config_drive_raw_hhd
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+raw_hdd = false
+
+# DEPRECATED: Look for a config drive in the attached cdrom drives (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/config_drive_cdrom
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+cdrom = true
+
+# DEPRECATED: Look for a config drive in VFAT filesystems (boolean value)
+# Deprecated group/name - [DEFAULT]/config_drive_vfat
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+vfat = false
+
+# Supported formats of a configuration drive (list value)
+# Deprecated group/name - [DEFAULT]/config_drive_types
+types = iso
+
+# Supported configuration drive locations (list value)
+# Deprecated group/name - [DEFAULT]/config_drive_locations
+locations = cdrom
+
+
+[ec2]
+
+#
+# From cloudbaseinit.conf
+#
+
+# The base URL where the service looks for metadata (string value)
+# Deprecated group/name - [DEFAULT]/ec2_metadata_base_url
+#metadata_base_url = http://169.254.169.254/
+
+# Add a route for the metadata ip address to the gateway (boolean value)
+# Deprecated group/name - [DEFAULT]/ec2_add_metadata_private_ip_route
+#add_metadata_private_ip_route = true
+
+# Whether to disable the validation of HTTPS certificates. (boolean value)
+#https_allow_insecure = false
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CAs.
+# (string value)
+#https_ca_bundle = <None>
+
+
+[maas]
+
+#
+# From cloudbaseinit.conf
+#
+
+# The base URL for MaaS metadata (string value)
+# Deprecated group/name - [DEFAULT]/maas_metadata_url
+#metadata_base_url = <None>
+
+# The MaaS OAuth consumer key (string value)
+# Deprecated group/name - [DEFAULT]/maas_oauth_consumer_key
+#oauth_consumer_key =
+
+# The MaaS OAuth consumer secret (string value)
+# Deprecated group/name - [DEFAULT]/maas_oauth_consumer_secret
+#oauth_consumer_secret =
+
+# The MaaS OAuth token key (string value)
+# Deprecated group/name - [DEFAULT]/maas_oauth_token_key
+#oauth_token_key =
+
+# The MaaS OAuth token secret (string value)
+# Deprecated group/name - [DEFAULT]/maas_oauth_token_secret
+#oauth_token_secret =
+
+# Whether to disable the validation of HTTPS certificates. (boolean value)
+#https_allow_insecure = false
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CAs.
+# (string value)
+#https_ca_bundle = <None>
+
+
+[openstack]
+
+#
+# From cloudbaseinit.conf
+#
+
+# The base URL where the service looks for metadata (string value)
+#metadata_base_url = http://169.254.169.254/
+
+# Add a route for the metadata ip address to the gateway (boolean value)
+#add_metadata_private_ip_route = true
+
+# Whether to disable the validation of HTTPS certificates. (boolean value)
+#https_allow_insecure = false
+
+# The path to a CA_BUNDLE file or directory with certificates of trusted CAs.
+# (string value)
+#https_ca_bundle = <None>
+
+[nocloud]
+
+metadata_file = "META_DATA"
+userdata_file = "USER_DATA"


### PR DESCRIPTION
Add required Proxmox cidata NoCloud config drive support.

Proxmox has two types for ISO based configdrives that can be created,
one for Windows, and one for non-Windows OS types.

The Windows type is a configdrivev2 ISO type, that is similar but not
quite the same with the OpenStack configdrive v2: the label is config-2.

This change focuses on the NoCloud ISO type, that is similar but not the
same with the NoCloud implementation: the label is cidata, and the
file structure is as follows:

```
META_DATA -> file containing at most 3 entries, in the format key:
value - instance-id, network-interfaces, hostname.
NETWORK_CONFIG -> network configuration, standard format.
USER_DATA -> user data, standard format.

```

The currently created Proxmox cidata ISO usage with NoCloud provider
shows the following errors:

```
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'manage_etc_hosts' is currently not supported
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'fqdn' is currently not supported
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'user' is currently not supported
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'password' is currently not supported
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'chpasswd' is currently not supported
ERROR cloudbaseinit.plugins.common.userdataplugins.cloudconfig [-] Plugin 'package_upgrade' is currently not supported

INFO cloudbaseinit.metadata.services.nocloudservice [-] V2 network metadata not found
```

The support for `manage_etc_hosts` cannot be added, as it cannot be mapped to an existing Windows feature.

The support for `fqdn` can be added easily, as it is the same as the `set_hostname ` one.

The support for `user` with the  `default` entry cannot be added, as it cannot be mapped to an existing Windows feature. This feature is in some sense implicit.

The support for `password` can be added as per https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main.
The support for `chpasswd` can be added as per https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main.

The support for `package_upgrade` can be added as per the https://cloudbase-init.readthedocs.io/en/latest/plugins.html#windows-auto-updates-main.

The support for v2 network metadata is in progress here: https://github.com/cloudbase/cloudbase-init/pull/164